### PR TITLE
[#34] fix overlap content in tables with extra class option

### DIFF
--- a/demo/lists_tables.rst
+++ b/demo/lists_tables.rst
@@ -369,3 +369,19 @@ Test to see that tables behave well with nested paragraphs.
 |            | .{ }     | Bit-field concatenation |
 +------------+----------+-------------------------+
 
+
+Tables with non-breakable text
+------------------------------
+
+.. list-table::
+  :widths: 10,80
+  :class: table-wrap
+
+  * - True
+    - This text could be broken at all whitespaces occuring in the text
+  * - False
+    - This is a code block line, normaly could also be broken at all whitespaces in text
+  * - True
+    - This_is_a_non_breakable_line_due_to_no_whitespaces_in_text_at_all_which_is_not_readable_without_breaking_it_working_if_you_can_read_THIS
+
+

--- a/demo/lists_tables.rst
+++ b/demo/lists_tables.rst
@@ -296,6 +296,8 @@ False  True   True
 True   True   True
 =====  =====  ======
 
+.. rst-class:: break_before, ssp-landscape, break_after
+
 Giant Tables
 ^^^^^^^^^^^^
 
@@ -310,6 +312,7 @@ Giant Tables
 +------------+------------+-----------+------------+------------+-----------+------------+------------+-----------+------------+------------+-----------+
 | body row 1 | column 2   | column 3  | body row 1 | column 2   | column 3  | body row 1 | column 2   | column 3  | body row 1 | column 2   | column 3  |
 +------------+------------+-----------+------------+------------+-----------+------------+------------+-----------+------------+------------+-----------+
+
 
 List Tables
 -----------
@@ -375,7 +378,7 @@ Tables with non-breakable text
 
 .. list-table::
   :widths: 10,80
-  :class: table-wrap
+  :class: ssp-table-wrap
 
   * - True
     - This text could be broken at all whitespaces occuring in the text

--- a/demo/needs.json
+++ b/demo/needs.json
@@ -1,0 +1,70 @@
+{
+    "created": "2022-09-19T15:12:30.462819",
+    "current_version": "1.0",
+    "project": "Sphinx-SimplePDF-DEMO",
+    "versions": {
+        "1.0": {
+            "created": "2022-09-19T15:12:30.462811",
+            "filters": {},
+            "filters_amount": 0,
+            "needs": {
+                "REQ_021": {
+                    "avatar": "",
+                    "closed_at": "",
+                    "completion": "",
+                    "created_at": "",
+                    "description": "The ``Sphinx-Needs Theme`` for PDF shall support also text even if imported. This_is_a_non_breakable_line_due_to_no_whitespaces_in_text_at_all_which_is_not_readable_without_breaking_it_working_if_you_can_read_THIS",
+                    "docname": "sphinx_needs",
+                    "duration": "",
+                    "external_css": "external_link",
+                    "external_url": null,
+                    "full_title": "Sphinx-Needs Theme extension from import",
+                    "has_dead_links": "",
+                    "has_forbidden_dead_links": "",
+                    "hidden": "",
+                    "id": "REQ_021",
+                    "id_complete": "REQ_021",
+                    "id_parent": "REQ_021",
+                    "id_prefix": "",
+                    "is_external": false,
+                    "is_modified": false,
+                    "is_need": true,
+                    "is_part": false,
+                    "layout": "",
+                    "links": [],
+                    "max_amount": "",
+                    "max_content_lines": "",
+                    "modifications": 0,
+                    "parent_need": null,
+                    "parent_needs": [],
+                    "parent_needs_back": [],
+                    "parts": {},
+                    "post_template": null,
+                    "pre_template": null,
+                    "query": "",
+                    "section_name": "Another",
+                    "sections": [
+                        "Another"
+                    ],
+                    "service": "",
+                    "signature": "",
+                    "specific": "",
+                    "status": "done",
+                    "style": null,
+                    "tags": [
+                        "sphinx",
+                        "extension"
+                    ],
+                    "template": null,
+                    "title": "Sphinx-Needs Theme extension support with code examples from imported needs",
+                    "type": "req",
+                    "type_name": "Requirement",
+                    "updated_at": "",
+                    "url": "",
+                    "user": ""
+                }
+            },
+            "needs_amount": 1
+        }
+    }
+}

--- a/demo/sphinx_needs.rst
+++ b/demo/sphinx_needs.rst
@@ -46,7 +46,6 @@ This is the same table, but with datatables style. This normally adds a scrollba
 .. needtable::
    :filter: 'sphinx' in tags
    :style: datatables
-   :class: table-wrap
    :colwidths: 10,10,10,10,60
    :columns: id, title, status, tags, content
 
@@ -59,6 +58,12 @@ Using ``plantuml`` to render image.
 .. needflow::
    :filter: 'sphinx' in tags
 
+Sphinx-Needs needimport
+=======================
+
+.. needimport:: needs.json
+   :tags: imported
+   :collapse: True
 
 CSV Table
 ---------

--- a/demo/sphinx_needs.rst
+++ b/demo/sphinx_needs.rst
@@ -24,6 +24,15 @@ Sphinx-Needs objects
       :align: center
 
 
+.. req:: Sphinx-Needs Theme extension support with code examples
+   :id: REQ_002
+   :status: done
+   :tags: sphinx, extension
+
+   The ``Sphinx-Needs Theme`` for PDF shall support also code examples or inline codes with long text
+
+   This_is_a_non_breakable_line_due_to_no_whitespaces_in_text_at_all_which_is_not_readable_without_breaking_it_working_if_you_can_read_THIS
+
 
 Sphinx-Needs tables
 ===================
@@ -31,6 +40,16 @@ Sphinx-Needs tables
 .. needtable::
    :filter: 'sphinx' in tags
    :columns: id, title, status, tags
+
+This is the same table, but with datatables style. This normally adds a scrollbar to tables if extending the normal layout size
+
+.. needtable::
+   :filter: 'sphinx' in tags
+   :style: datatables
+   :class: table-wrap
+   :colwidths: 10,10,10,10,60
+   :columns: id, title, status, tags, content
+
 
 Sphinx-Needs needflow
 =====================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ Release 1.4
 * **Enhancement**: Adds `demo` PDF to test various layout & style elements.
 * **Enhancement**: Replace not-open fonts with open-source fonts.
 * **Enhancement**: All fonts are provided by this package. No pre-installed fonts are needed.
+* **Enhancement**: [#19] Simple PDF customization with header and bottom page content
+* **Enhancement**: Add class wrapper to switch paper orientation, e.g. for large tables
+* **Bugfix**: [#34] handling word wrap in tables
 * **Bugfix**: Image handling is done much better.
 * **Bugfix**: Font location fixes -> No fonts warnings anymore.
 * **Bugfix**: ``html_theme_options`` gets overwritten to suppress Sphinx warnings.

--- a/docs/css.rst
+++ b/docs/css.rst
@@ -22,6 +22,44 @@ If this is set to ``break``, then a page break will be introduced in front of th
        :file: example.csv
        :class: break
 
+Page Orientation
+~~~~~~~~~~~~~~~~
+
+The default orientation is portrait. To change the page orientation for a side, you can add the css class
+``ssp-landscape`` to
+
+* directives supporting the option ``:class:``
+* or by using the ``.. rst-class::`` directive in the document with classes as arguments
+* or by using the ``.. container::`` directive with the options for the used classes
+
+**Example**::
+
+    .. rst-class:: break_before, ssp-landscape, break_after
+
+    .. csv-table:: CSV Table
+       :file: example.csv
+
+If the default page orientation is changed to landscape, you can use ``ssp-portrait`` to change to portrait.
+
+Table content wrap
+~~~~~~~~~~~~~~~~~~
+
+By default table content is wrapped at whitespaces. If you have table content that can not be wrapped due to
+side limitations, the table is drawn out of the margins. This behaviour can be changed by using the css class
+``ssp-table-wrap``. This allows the table to break the content anywhere.
+
+This requires a fixed table layout, so you have to set the ``widths`` options (or e.g. ``colwidths`` option
+in needtable) to get good results.
+
+This option is by default added to all ``Sphinx-Needs`` elements or could be explicitly set by applying the
+``ssp-table-wrap`` as ``style`` option to ``Sphinx-Needs`` directives.
+
+**Example**::
+
+    .. list-table::
+        :widths: 10,80
+        :class: ssp-table-wrap
+
 Sphinx-Needs elements
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_needs.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_needs.scss
@@ -1,3 +1,10 @@
 .needs_style_break {
-  page-break-before: always;
+    page-break-before: always;
+}
+
+table.need, table.NEEDS_DATATABLES, .needs_style_ssp-table-wrap {
+    table-layout: fixed;
+    td, th {
+        overflow-wrap: break-word;
+    }
 }

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_pages.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_pages.scss
@@ -16,6 +16,22 @@
     page-break-before: always;
 }
 
+@page landscape_page {
+    size: landscape;
+}
+
+@page portrait_page {
+    size: portrait;
+}
+
+.ssp-portrait {
+    page: portrait_page;
+
+}
+.ssp-landscape {
+    page: landscape_page;
+}
+
 @page {
   padding-top: 1em;
 

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
@@ -2,6 +2,13 @@ table.break {
     page-break-before: always;
 }
 
+table.table-wrap {
+    table-layout: fixed;
+    td, th {
+        overflow-wrap: break-word;
+    }
+}
+
 table.docutils {
     width: 100%;
     max-width: 100%;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
@@ -2,7 +2,7 @@ table.break {
     page-break-before: always;
 }
 
-table.table-wrap {
+table.ssp-table-wrap {
     table-layout: fixed;
     td, th {
         overflow-wrap: break-word;


### PR DESCRIPTION
This fix adds an extra class option in the css to allow html output to break in words to render content.
This solution allows to fine tune the behaviour for individual tables and respects given colwidths in needs table directives.

Please feel free to improve css handling/naming/subclassing, i am no expert in css.
