### PR TITLE
[] allow weasyprint subprocess flags and process timeout via configur…

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -102,4 +102,20 @@ You can see an example in our :download:`PDF Demo <_static/Sphinx-SimplePDF-DEMO
    The debug output contains absolute file paths and maybe other critical information.
    Do not use for official PDF releases.
 
+simplepdf_weasyprint_flags
+--------------------------
+List of flags to pass to **weasyprint** subprocess. This may be helpfull in debugging the pdf creation
 
+``simplepdf_weasyprint_flags = ['-v']``
+
+.. warning::
+
+   The flags should only pass switches to **weasyprint**, input and output file names are appended by **Sphinx-SimplePDF**
+
+simplepdf_weasyprint_timeout
+----------------------------
+
+In rare cases **weasyprint** seems to run into infinite loops during processing of the input file.
+To avoid blocking CI jobs a timeout can be configured. The build is aborted with a `` subprocess.TimeoutExpired¶`` exception.
+
+``simplepdf_weasyprint_timeout = 300``

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -85,14 +85,19 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
         with open(index_path, 'wt', encoding='utf-8') as index_file:
             index_file.writelines(new_index_html)
 
+        args = [ 'weasyprint' ]
 
-        args = [
-            'weasyprint',
+        if isinstance(self.config['simplepdf_weasyprint_flags'], list) and (0 < len(self.config['simplepdf_weasyprint_flags'])) :
+            args.extend(self.config['simplepdf_weasyprint_flags'])
+
+        args.extend( [
             index_path,
             os.path.join(self.app.outdir, f'{self.app.config.project}.pdf'),
+        ])
 
-        ]
-        subprocess.run(args)
+        timeout = self.config['simplepdf_weasyprint_timeout']
+
+        subprocess.check_output(args, timeout=timeout, text=True)
 
     def _toctree_fix(self, html):
         soup = BeautifulSoup(html, "html.parser")
@@ -108,6 +113,8 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("simplepdf_vars", {}, "html", types=[dict])
     app.add_config_value("simplepdf_debug", False, "html", types=bool)
+    app.add_config_value("simplepdf_weasyprint_timeout", None, "html", types=[int])
+    app.add_config_value("simplepdf_weasyprint_flags", None, "html", types=[list])
     app.add_builder(SimplePdfBuilder)
 
     return {


### PR DESCRIPTION
In rare cases i ran into infinite loops with weasyprint, not seeing any output, not can give any flags, breaking my CI jobs.
This was the intention to configure the subprocess to:

* support flags from configuration, e.g. --debug or --verbose flags
* timeout subprocess after configured timeout to avoid stucking in CI jobs