### PR TITLE
[#60] Fix html anchors

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Contributors
 ------------
 
 Jörg Kreuzberger <j.kreuzberger@procitec.de>
+Sandi Šaban <saban.sandi@gmail.com>

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Release 1.6
 -----------
 :released: under development
 
+* **Bugfix** [#60] Fix TOC hrefs for sections that use file title anchors.
 
 Release 1.5
 -----------
@@ -56,6 +57,3 @@ Release 1.1
 Release 1.0
 -----------
 :released: 18.08.2022
-
-
-

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -5,6 +5,7 @@ import subprocess
 import sass
 
 from bs4 import BeautifulSoup
+from docutils.nodes import make_id
 
 
 from sphinx import __version__
@@ -127,6 +128,8 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             links = sidebar.find_all('a', class_='reference internal')
             for link in links:
                 link['href'] = link['href'].replace(f'{self.app.config.root_doc}.html', '')
+                if link['href'].startswith('#document-'):
+                    link['href'] = '#' + make_id(link.text)
 
         return soup.prettify(formatter='html')
 


### PR DESCRIPTION
For the very first rst file toc entry, Sphinx doesn't add an anchor, but instead uses file's title.
Because of that, some links in Table of contents of PDF document are not correct, resulting in wrong page numbers.
Fix replaces all such anchors with the correct ones, after the creation of HTML document.