### PR TITLE
add conf.py option to force weasyprint API usage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,9 +3,10 @@ Changelog
 
 Release 1.6
 -----------
-:released: under development
+:released: 20.01.2023
 
 * **Bugfix** [#60] Fix TOC hrefs for sections that use file title anchors.
+* **Enhancement** [#62] Added config option to build PDFs with the weasyprint Python API instead of the binary. 
 
 Release 1.5
 -----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ extensions = [
     'sphinx_copybutton',
 ]
 
-version = "1.6"
+version = "1.6.0"
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,9 @@ simplepdf_vars = {
     'cover-bg': 'url(cover-bg.jpg) no-repeat center'
 }
 
+# use this to force 
+# simplepdf_use_weasyprint_api = True
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ simplepdf_vars = {
     'cover-bg': 'url(cover-bg.jpg) no-repeat center'
 }
 
-# use this to force 
+# use this to force using the weasyprint python API instead of building via the binary
 # simplepdf_use_weasyprint_api = True
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -120,6 +120,16 @@ You can see an example in our :download:`PDF Demo <_static/Sphinx-SimplePDF-DEMO
    The debug output contains absolute file paths and maybe other critical information.
    Do not use for official PDF releases.
 
+simplepdf_use_weasyprint_api
+----------------------------
+.. versionadded:: 1.6
+
+This forces simplepdf to use the weasyprint `python API <https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#python-api>`_ instead of calling the binary via subproces.
+
+.. warning::
+
+   Other variables like `simplepdf_weasyprint_flags`_ will not work when using the API.
+
 simplepdf_weasyprint_flags
 --------------------------
 .. versionadded:: 1.5

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,6 +126,8 @@ simplepdf_use_weasyprint_api
 
 This forces simplepdf to use the weasyprint `python API <https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#python-api>`_ instead of calling the binary via subproces.
 
+``simplepdf_use_weasyprint_api = True``
+
 .. warning::
 
    Other variables like `simplepdf_weasyprint_flags`_ will not work when using the API.

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -119,7 +119,6 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
         timeout = self.config['simplepdf_weasyprint_timeout']
 
-        
         if self.config['simplepdf_use_weasyprint_api']:
             
             doc = weasyprint.HTML(index_path)

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any, Dict
 import subprocess
+import weasyprint
 
 import sass
 
@@ -118,7 +119,17 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
         timeout = self.config['simplepdf_weasyprint_timeout']
 
-        subprocess.check_output(args, timeout=timeout, text=True)
+        
+        if self.config['simplepdf_use_weasyprint_api']:
+            
+            doc = weasyprint.HTML(index_path)
+
+            doc.write_pdf(
+                target=os.path.join(self.app.outdir, f'{file_name}'),
+            )
+        
+        else:
+            subprocess.check_output(args, timeout=timeout, text=True)
 
     def _toctree_fix(self, html):
         soup = BeautifulSoup(html, "html.parser")
@@ -140,6 +151,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("simplepdf_debug", False, "html", types=bool)
     app.add_config_value("simplepdf_weasyprint_timeout", None, "html", types=[int])
     app.add_config_value("simplepdf_weasyprint_flags", None, "html", types=[list])
+    app.add_config_value("simplepdf_use_weasyprint_api", None, "html", types=[bool])
     app.add_config_value("simplepdf_theme", "simplepdf_theme", "html", types=[str])
     app.add_config_value("simplepdf_theme_options", {}, "html", types=[dict])
     app.add_config_value("simplepdf_sidebars", {'**': ["localtoc.html"]}, "html", types=[dict])


### PR DESCRIPTION
We need to release a new version to pypi for my specific use case since I can not checkout from a branch in my build environment. 

Maybe we should release 1.5.1 for this and wait for more features for 1.6