### PR TITLE
Adding retry option if weasyprint process gets timed out

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -153,6 +153,15 @@ To avoid blocking CI jobs a timeout can be configured. The build is aborted with
 
 ``simplepdf_weasyprint_timeout = 300``
 
+simplepdf_weasyprint_retries
+----------------------------
+.. versionadded:: 1.6
+
+In rare cases **weasyprint** seems to run into infinite loops during processing of the input file.
+In case a ``subprocess.TimeoutExpired`` exception occured and retries are configured **weasyprint** is started again.
+
+``simplepdf_weasyprint_retries = 1``
+
 simplepdf_theme
 ---------------
 .. versionadded:: 1.5


### PR DESCRIPTION
Related to #48 we have problems to get it stable running in your CI System on windows. This affects all up to the newest version of weasyprint. Workaround by limiting the number of process to one for sphinx_simplepdf builds limits us in CI speed and also leads to failed builds sometimes.

So i decided to add a retry configuration option. This could help us in case of timeouts in the pdf generation to retry. I currently use 3 times and builds are not broken any more.

This only works when using weasyprint as executable, not as module. But only in this case the timeout option is also usable.