### PR TITLE
[#70] try to weasyprint 1 + given retries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Release 1.7
+-----------
+
+* **Bugfix** [#70] Added config option to build PDFs retries times if weasyprint binary fails to build.
+
+
 Release 1.6
 -----------
 :released: 20.01.2023

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -131,7 +131,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
         
         else:
             retries = self.config['simplepdf_weasyprint_retries']
-            for n in range(retries):
+            for n in range(1 + retries):
                 try:
                     subprocess.check_output(args, timeout=timeout, text=True)
                     break


### PR DESCRIPTION
Due to misconfiguration the default implementation does not make a pdf any more cause number of retries is 0 and the loop does not start. Due to the meaning of the configuration value the implementation is changed to try it `1 + retries` time to produce the pdf