### PR TITLE
[#70] retry also in CalledProcessError 

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -153,8 +153,8 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                         else:
                             print(line)
                     break
-                except subprocess.TimeoutExpired:
-                    logger.warning(f"TimeoutExpired in weasyprint, retrying")
+                except: # subprocess.TimeoutExpired or subprocess.CalledProcessError
+                    logger.warning(f"exception in weasyprint, retrying")
 
                     if n == retries - 1:
                         raise RuntimeError(f"maximum number of retries {retries} failed in weasyprint")


### PR DESCRIPTION
In CI builds we sometime also see this error from weasyprint call:
`due to sometimes GLib:ERROR:.../glib-2.70.2/glib/gthread.c:814:g_thread_proxy: assertion failed: (data)`.

So the retry mechanism will be used on every exception occuring.