### PR TITLE
[#66] remove 'display: inline-block' from inline code blocks

### DIFF
--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
@@ -171,6 +171,5 @@ img {
     color: #552977;
     background-color: #f1f1f1;
     font-size: 9pt;
-    display: inline-block;
     padding: 1pt 3pt;
 }


### PR DESCRIPTION
Fixes #66 
    
inline code blocks should not be assigned 'display: inline-block'
despite their namesake. without `inline-block`.
    
Setting display to `inline-block` turns `<code>` into a block element,
which when applied to an exceptionally long element (i.e. long
non-breaking 'pre'-formatted lines) makes ordering and sizing of
elements around it weird.

---

Before:

![Screenshot 2023-05-13 at 00 33 11](https://github.com/useblocks/sphinx-simplepdf/assets/6762123/ab570306-4cea-42ed-a128-7b7fe8cc3f88)


After removing `display: inline-block`:

![Screenshot 2023-05-13 at 00 31 27](https://github.com/useblocks/sphinx-simplepdf/assets/6762123/57801de1-217a-49fb-810d-9e0f3737f878)