### PR TITLE
[#40] Filtering option for weasyprint output to find relevant messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Release 1.7
 
 * **Bugfix** [#82] TOC Tree Fix and Page Break Handling for document handling
 * **Bugfix** [#70] Added config option to build PDFs retries times if weasyprint binary fails to build.
-
+* **Enhancement** [#40] Added config option to filter warnings from weasyprint.
 
 Release 1.6
 -----------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -181,4 +181,13 @@ Additional options for the theme. The default theme ``simplepdf_theme`` inherits
 :nocover: Do not display cover pages (front and back cover)
 
 
+simplepdf_weasyprint_filter
+---------------------------
+.. versionadded:: 1.6
 
+If **weasyprint** is used as executable the output contains warnings and errors from **weasyprint**.
+To reduce output noise the output can be filtered by a list of regular expressions given in this configuration option.
+
+``simplepdf_weasyprint_filter = ["WARNING: Ignored"]``
+
+To suppress all output, the quite flag `-q` should be used.

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -135,7 +135,6 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
         filter_pattern = "(?:% s)" % "|".join(filter_list) if 0 < len(filter_list) else None
 
         if self.config["simplepdf_use_weasyprint_api"]:
-
             doc = weasyprint.HTML(index_path)
 
             doc.write_pdf(

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import Any, Dict
 import subprocess
 import weasyprint
@@ -15,7 +16,9 @@ from sphinx.builders.singlehtml import SingleFileHTMLBuilder
 from sphinx_simplepdf.builders.debug import DebugPython
 
 from sphinx.util import logging
+
 logger = logging.getLogger(__name__)
+
 
 class SimplePdfBuilder(SingleFileHTMLBuilder):
     name = "simplepdf"
@@ -31,32 +34,38 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
         # We need to overwrite some config values, as they are set for the normal html build, but
         # simplepdf can normally not handle them.
-        self.app.config.html_sidebars = self.app.config.simplepdf_sidebars;
-        self.app.config.html_theme_options = self.app.config.simplepdf_theme_options;  # Sphinx would write warnings, if given options are unsupported.
+        self.app.config.html_sidebars = self.app.config.simplepdf_sidebars
+        self.app.config.html_theme_options = self.app.config.simplepdf_theme_options
+        # Sphinx would write warnings, if given options are unsupported.
 
         # Add SimplePDf specific functions to the html_context. Mostly needed for printing debug information.
-        self.app.config.html_context['simplepdf_debug'] = self.config['simplepdf_debug']
-        self.app.config.html_context['pyd'] = DebugPython()
+        self.app.config.html_context["simplepdf_debug"] = self.config["simplepdf_debug"]
+        self.app.config.html_context["pyd"] = DebugPython()
 
         debug_sphinx = {
-            'version': __version__,
-            'confidr': self.app.confdir,
-            'srcdir': self.app.srcdir,
-            'outdir': self.app.outdir,
-            'extensions': self.app.config.extensions,
-            'simple_config': {x.name: x.value for x in self.app.config if x.name.startswith('simplepdf')}
+            "version": __version__,
+            "confidr": self.app.confdir,
+            "srcdir": self.app.srcdir,
+            "outdir": self.app.outdir,
+            "extensions": self.app.config.extensions,
+            "simple_config": {x.name: x.value for x in self.app.config if x.name.startswith("simplepdf")},
         }
-        self.app.config.html_context['spd'] = debug_sphinx
+        self.app.config.html_context["spd"] = debug_sphinx
 
         # Generate main.css
-        print('Generating css files from scss-templates')
-        css_folder = os.path.join(self.app.outdir, f'_static')
-        scss_folder = os.path.join(os.path.dirname(__file__), '..', 'themes', 'simplepdf_theme',
-                                   'static', 'styles', 'sources')
-        sass.compile(dirname=(scss_folder, css_folder), output_style='nested',
-                     custom_functions={sass.SassFunction('config', ('$a', '$b'), self.get_config_var),
-                                       sass.SassFunction('theme_option', ('$a', '$b'), self.get_theme_option_var)}
-                     )
+        print("Generating css files from scss-templates")
+        css_folder = os.path.join(self.app.outdir, f"_static")
+        scss_folder = os.path.join(
+            os.path.dirname(__file__), "..", "themes", "simplepdf_theme", "static", "styles", "sources"
+        )
+        sass.compile(
+            dirname=(scss_folder, css_folder),
+            output_style="nested",
+            custom_functions={
+                sass.SassFunction("config", ("$a", "$b"), self.get_config_var),
+                sass.SassFunction("theme_option", ("$a", "$b"), self.get_theme_option_var),
+            },
+        )
 
     def get_config_var(self, name, default):
         """
@@ -90,53 +99,65 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             return default
         return simplepdf_theme_options[name]
 
-
     def finish(self) -> None:
         super().finish()
 
-        index_path = os.path.join(self.app.outdir, f'{self.app.config.root_doc}.html')
+        index_path = os.path.join(self.app.outdir, f"{self.app.config.root_doc}.html")
 
         # Manipulate index.html
-        with open(index_path, 'rt', encoding='utf-8') as index_file:
+        with open(index_path, "rt", encoding="utf-8") as index_file:
             index_html = "".join(index_file.readlines())
 
         new_index_html = self._toctree_fix(index_html)
 
-        with open(index_path, 'wt', encoding='utf-8') as index_file:
+        with open(index_path, "wt", encoding="utf-8") as index_file:
             index_file.writelines(new_index_html)
 
-        args = [ 'weasyprint' ]
+        args = ["weasyprint"]
 
-        if isinstance(self.config['simplepdf_weasyprint_flags'], list) and (0 < len(self.config['simplepdf_weasyprint_flags'])) :
-            args.extend(self.config['simplepdf_weasyprint_flags'])
+        if isinstance(self.config["simplepdf_weasyprint_flags"], list) and (
+            0 < len(self.config["simplepdf_weasyprint_flags"])
+        ):
+            args.extend(self.config["simplepdf_weasyprint_flags"])
 
         file_name = self.app.config.simplepdf_file_name or f"{self.app.config.project}.pdf"
 
-        args.extend([
-            index_path,
-            os.path.join(self.app.outdir, f'{file_name}'),
-        ])
+        args.extend(
+            [
+                index_path,
+                os.path.join(self.app.outdir, f"{file_name}"),
+            ]
+        )
 
-        timeout = self.config['simplepdf_weasyprint_timeout']
+        timeout = self.config["simplepdf_weasyprint_timeout"]
 
-        if self.config['simplepdf_use_weasyprint_api']:
-            
+        filter_list = self.config["simplepdf_weasyprint_filter"]
+        filter_pattern = "(?:% s)" % "|".join(filter_list) if 0 < len(filter_list) else None
+
+        if self.config["simplepdf_use_weasyprint_api"]:
+
             doc = weasyprint.HTML(index_path)
 
             doc.write_pdf(
-                target=os.path.join(self.app.outdir, f'{file_name}'),
+                target=os.path.join(self.app.outdir, f"{file_name}"),
             )
-        
+
         else:
-            retries = self.config['simplepdf_weasyprint_retries']
+            retries = self.config["simplepdf_weasyprint_retries"]
             for n in range(1 + retries):
                 try:
-                    subprocess.check_output(args, timeout=timeout, text=True)
+                    wp_out = subprocess.check_output(args, timeout=timeout, text=True, stderr=subprocess.STDOUT)
+
+                    for line in wp_out.splitlines():
+                        if filter_pattern is not None and re.match(filter_pattern, line):
+                            pass
+                        else:
+                            print(line)
                     break
                 except subprocess.TimeoutExpired:
                     logger.warning(f"TimeoutExpired in weasyprint, retrying")
 
-                    if  n == retries-1:
+                    if n == retries - 1:
                         raise RuntimeError(f"maximum number of retries {retries} failed in weasyprint")
 
     def _toctree_fix(self, html):
@@ -144,7 +165,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
         sidebar = soup.find("div", class_="sphinxsidebarwrapper")
 
         if sidebar is not None:
-            links = sidebar.find_all('a', class_='reference internal')
+            links = sidebar.find_all("a", class_="reference internal")
             for link in links:
                 link["href"] = link["href"].replace(f"{self.app.config.root_doc}.html", "")
 
@@ -162,7 +183,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                 if len(headings) - 1 == number:
                     class_attr.append("last")
 
-        return soup.prettify(formatter='html')
+        return soup.prettify(formatter="html")
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:
@@ -172,10 +193,11 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value("simplepdf_weasyprint_timeout", None, "html", types=[int])
     app.add_config_value("simplepdf_weasyprint_retries", 0, "html", types=[int])
     app.add_config_value("simplepdf_weasyprint_flags", None, "html", types=[list])
+    app.add_config_value("simplepdf_weasyprint_filter", [], "html", types=[list])
     app.add_config_value("simplepdf_use_weasyprint_api", None, "html", types=[bool])
     app.add_config_value("simplepdf_theme", "simplepdf_theme", "html", types=[str])
     app.add_config_value("simplepdf_theme_options", {}, "html", types=[dict])
-    app.add_config_value("simplepdf_sidebars", {'**': ["localtoc.html"]}, "html", types=[dict])
+    app.add_config_value("simplepdf_sidebars", {"**": ["localtoc.html"]}, "html", types=[dict])
     app.add_builder(SimplePdfBuilder)
 
     return {


### PR DESCRIPTION
The output of weasyprint has many non relevant informations and errors about css file the user cannot change.
To see relevant messages from users css and document, the output could be filtered by given filter string to reduce amount of messages in the IDE