### PR TITLE
[#82] fix assign class attribute

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -186,6 +186,8 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                 if len(headings) - 1 == number:
                     class_attr.append("last")
 
+                heading.attrs["class"] = class_attr
+
         return soup.prettify(formatter="html")
 
 


### PR DESCRIPTION
During merging serveral PR's two lines seems to be "forgotten". These assign the modified class attributes to the html.