### PR TITLE
add duplicate check to toctree_fix function

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -173,6 +173,44 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             for link in links:
                 link["href"] = link["href"].replace(f"{self.app.config.root_doc}.html", "")
 
+            print(links)
+
+            # search for duplicates
+            counts = dict(Counter([str(x).split(">")[0] for x in links]))
+            duplicates = {key: value for key, value in counts.items() if value > 1}
+            print(duplicates)
+
+            if duplicates:
+                print("found duplicate references in toctree attempting to fix")
+
+            for text, counter in duplicates.items():
+
+                ref = re.findall("href=\"#.*\"", str(text))
+
+                cleaned_ref_toc = ref[0].strip("href=\"")
+                cleaned_ref_target = ref[0].strip("href=\"#")
+
+                # occurences = soup.find_all('a', attrs={"class": "headerlink", "href": cleaned_ref})
+                occurences = soup.find_all('section', attrs={"id": cleaned_ref_target})
+                # print(occurences)
+
+                # rename duplicate references
+
+                replace_counter = 0
+
+                for link in links:
+                    if link["href"] == cleaned_ref_toc:
+                        # edit reference in table of content
+                        link["href"] = link["href"] + "-" + str(replace_counter + 1)
+
+                        # edit target reference
+                        # occurences[replace_counter]["href"] = occurences[replace_counter]["href"] + "-" + str(replace_counter + 1)
+                        occurences[replace_counter]["id"] = occurences[replace_counter]["id"] + "-" + str(
+                            replace_counter + 1)
+
+                        replace_counter += 1
+
+
         for heading_tag in ["h1", "h2"]:
             headings = soup.find_all(heading_tag, class_="")
             for number, heading in enumerate(headings):
@@ -188,40 +226,6 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                     class_attr.append("last")
 
                 heading.attrs["class"] = class_attr
-
-        # search for duplicates
-        counts = dict(Counter(links))
-        duplicates = {key:value for key, value in counts.items() if value > 1}
-        
-        if duplicates:
-            print("found duplicate references in toctree attempting to fix")
-
-        for text, counter in duplicates.items():
-            
-            ref = re.findall("href=\"#.*\"", str(text))
-
-            cleaned_ref_toc = ref[0].strip("href=\"")
-            cleaned_ref_target = ref[0].strip("href=\"#")
-
-            
-            # occurences = soup.find_all('a', attrs={"class": "headerlink", "href": cleaned_ref})
-            occurences = soup.find_all('section', attrs={"id": cleaned_ref_target})
-            # print(occurences)
-
-            # rename duplicate references
-
-            replace_counter = 0
-            
-            for link in links:
-                if link["href"] == cleaned_ref_toc:
-                    # edit reference in table of content
-                    link["href"] = link["href"] + "-" + str(replace_counter + 1)
-                    
-                    # edit target reference
-                    # occurences[replace_counter]["href"] = occurences[replace_counter]["href"] + "-" + str(replace_counter + 1)
-                    occurences[replace_counter]["id"] = occurences[replace_counter]["id"] + "-" + str(replace_counter + 1)
-                    
-                    replace_counter += 1
 
         return soup.prettify(formatter="html")
 

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -173,12 +173,9 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             for link in links:
                 link["href"] = link["href"].replace(f"{self.app.config.root_doc}.html", "")
 
-            print(links)
-
             # search for duplicates
             counts = dict(Counter([str(x).split(">")[0] for x in links]))
             duplicates = {key: value for key, value in counts.items() if value > 1}
-            print(duplicates)
 
             if duplicates:
                 print("found duplicate references in toctree attempting to fix")
@@ -191,12 +188,9 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                 cleaned_ref_toc = ref[0].replace("href=\"", "").replace("\"", "") # "#target"
                 cleaned_ref_target = ref[0].replace("href=\"#", "").replace("\"", "") # "target"
 
-                # occurences = soup.find_all('a', attrs={"class": "headerlink", "href": cleaned_ref})
                 occurences = soup.find_all('section', attrs={"id": cleaned_ref_target})
-                # print(occurences)
 
                 # rename duplicate references, relies on fact -> order in toc is order of occurence in document
-
                 replace_counter = 0
 
                 for link in links:
@@ -205,12 +199,10 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                         link["href"] = link["href"] + "-" + str(replace_counter + 1)
 
                         # edit target reference
-                        # occurences[replace_counter]["href"] = occurences[replace_counter]["href"] + "-" + str(replace_counter + 1)
                         occurences[replace_counter]["id"] = occurences[replace_counter]["id"] + "-" + str(
                             replace_counter + 1)
 
                         replace_counter += 1
-
 
         for heading_tag in ["h1", "h2"]:
             headings = soup.find_all(heading_tag, class_="")

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import os
 import re
 from typing import Any, Dict
@@ -187,6 +188,40 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                     class_attr.append("last")
 
                 heading.attrs["class"] = class_attr
+
+        # search for duplicates
+        counts = dict(Counter(links))
+        duplicates = {key:value for key, value in counts.items() if value > 1}
+        
+        if duplicates:
+            print("found duplicate references in toctree attempting to fix")
+
+        for text, counter in duplicates.items():
+            
+            ref = re.findall("href=\"#.*\"", str(text))
+
+            cleaned_ref_toc = ref[0].strip("href=\"")
+            cleaned_ref_target = ref[0].strip("href=\"#")
+
+            
+            # occurences = soup.find_all('a', attrs={"class": "headerlink", "href": cleaned_ref})
+            occurences = soup.find_all('section', attrs={"id": cleaned_ref_target})
+            # print(occurences)
+
+            # rename duplicate references
+
+            replace_counter = 0
+            
+            for link in links:
+                if link["href"] == cleaned_ref_toc:
+                    # edit reference in table of content
+                    link["href"] = link["href"] + "-" + str(replace_counter + 1)
+                    
+                    # edit target reference
+                    # occurences[replace_counter]["href"] = occurences[replace_counter]["href"] + "-" + str(replace_counter + 1)
+                    occurences[replace_counter]["id"] = occurences[replace_counter]["id"] + "-" + str(replace_counter + 1)
+                    
+                    replace_counter += 1
 
         return soup.prettify(formatter="html")
 

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -186,15 +186,16 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             for text, counter in duplicates.items():
 
                 ref = re.findall("href=\"#.*\"", str(text))
-
-                cleaned_ref_toc = ref[0].strip("href=\"")
-                cleaned_ref_target = ref[0].strip("href=\"#")
+                
+                # clean href data for searching
+                cleaned_ref_toc = ref[0].replace("href=\"", "").replace("\"", "") # "#target"
+                cleaned_ref_target = ref[0].replace("href=\"#", "").replace("\"", "") # "target"
 
                 # occurences = soup.find_all('a', attrs={"class": "headerlink", "href": cleaned_ref})
                 occurences = soup.find_all('section', attrs={"id": cleaned_ref_target})
                 # print(occurences)
 
-                # rename duplicate references
+                # rename duplicate references, relies on fact -> order in toc is order of occurence in document
 
                 replace_counter = 0
 


### PR DESCRIPTION
fix for wrongly assigned page number in table of content in case of duplicated headlines