### PR TITLE
Bugfix: Error when root_doc points to a file in a subdirectory of src_dir

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -104,10 +104,25 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
             return default
         return simplepdf_theme_options[name]
 
+    def write_documents(self, _docnames: Set[str]) -> None:
+        self.prepare_writing(self.env.all_docs.keys())
+    
+        with progress_message(__("assembling single document"), nonl=False):
+            doctree = self.assemble_doctree()
+            self.env.toc_secnumbers = self.assemble_toc_secnumbers()
+            self.env.toc_fignumbers = self.assemble_toc_fignumbers()
+    
+        with progress_message(__("writing")):
+            self.write_doc_serialized(
+                self.config.root_doc.split("/")[-1], doctree  # type:ignore
+            )
+            self.write_doc(self.config.root_doc.split("/")[-1], doctree)  # type:ignore
+
+
     def finish(self) -> None:
         super().finish()
 
-        index_path = os.path.join(self.app.outdir, f"{self.app.config.root_doc}.html")
+        index_path = os.path.join(self.app.outdir, f"{self.app.config.root_doc.split("/")[-1]}.html")
 
         # Manipulate index.html
         with open(index_path, "rt", encoding="utf-8") as index_file:


### PR DESCRIPTION
Hello,

We are trying to build several pdf files from one project and to do so we launch sphinx for each pdf with a specific `root_doc` value.

Here is an example of the structure:

```
docs/
 |
 |--index.rst (used for the website creation)
 |--DocA/
 |   \--index.rst (root_doc of DocA)
 \--DocB/
     \--index.rst (root_doc of DocB)
```

When changing `root_doc` to `DocA/index.rst` to build DocA (instead of `index.rst` for the website), we get this structure:

```
docs/_build/dist
 |
 |--_static/
 |   \-- css files, images, etc..
 |--DocA/
 |   \--index.html
 ⋮
```

The problem here is that the generated `index.html` file references the `_static` folder as if it were at the same directory level, which is not the case. It completely breaks the generation of the pdf with weasyprint as no css is found.

The goal of this pull request is to fix this issue by preventing the generation of the `index.html` in a subfolder and instead generating it directly in dist.

This approach seems simpler to me instead of trying to generate the html file with the correct path to the `_static` folder. (as there may also be many other folders needed that are added by some extensions)
