### PR TITLE
[#116] Prettify breaks HTML formatting

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -224,7 +224,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
                 heading.attrs["class"] = class_attr
 
-        return soup.prettify(formatter="html")
+        return str(soup)
 
 
 def setup(app: Sphinx) -> Dict[str, Any]:

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -224,6 +224,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
                 heading.attrs["class"] = class_attr
 
+        logger.debug(soup.prettify(formatter="html"))
         return str(soup)
 
 


### PR DESCRIPTION
instead of returning prettified html (which should be used only for debugging purposes) return html code directly