### PR TITLE
New Feature: Add notoc theme option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -179,6 +179,7 @@ Additional options for the theme. The default theme ``simplepdf_theme`` inherits
 ``simplepdf_theme`` options:
 
 :nocover: Do not display cover pages (front and back cover)
+:notoc: Do not display the Table of Contents page
 
 
 simplepdf_weasyprint_filter

--- a/sphinx_simplepdf/themes/simplepdf_theme/page.html
+++ b/sphinx_simplepdf/themes/simplepdf_theme/page.html
@@ -1,5 +1,6 @@
 {%- extends "layout.html" %}
 {%- set render_cover = (not theme_nocover|tobool) %}
+{%- set render_toc = (not theme_notoc|tobool) %}
 
 {%- block extrahead %}
 
@@ -8,7 +9,7 @@
     {%- if render_cover %}
         {%- include "cover.html" -%}
     {%- endif %}
-    {{ sidebar() }}
+    {%- if render_toc %}{{ sidebar() }}{%- endif %}
 {% endblock %}
 {% block body %}
     {{ body }}

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_toc.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_toc.scss
@@ -71,6 +71,7 @@
 }
 
 // .. toctree:: config
+@if not $notoc {
 .sphinxsidebarwrapper {
 
     page-break-before: always;
@@ -159,3 +160,4 @@
         }
     }
 }
+} // @if not $notoc

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_variables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_variables.scss
@@ -25,3 +25,4 @@ $bottom-center-content: config('bottom-center-content', '') !default;
 $bottom-right-content: config('bottom-right-content', '') !default;
 
 $nocover: theme_option('nocover', false) !default;
+$notoc: theme_option('notoc', false) !default;

--- a/sphinx_simplepdf/themes/simplepdf_theme/theme.conf
+++ b/sphinx_simplepdf/themes/simplepdf_theme/theme.conf
@@ -14,3 +14,4 @@ globaltoc_collapse = false
 globaltoc_includehidden = false
 globaltoc_maxdepth = 1
 nocover = false
+notoc = false


### PR DESCRIPTION
Add a `notoc` option for [simplepdf_theme_options](https://sphinx-simplepdf.readthedocs.io/en/latest/configuration.html#simplepdf-theme-options) that hides the Table of Contents page from PDF output, mirroring the existing `nocover` option.

```python                                                                                                           
simplepdf_theme_options = {                                                                                           
    'notoc': True,                                                                                                    
}
```

Docs preview build: https://sphinx-simplepdf--125.org.readthedocs.build/en/125/configuration.html#simplepdf-theme-options