### PR TITLE
Docs: Fix typo in primary-opaque configuration variable name

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,7 +31,7 @@ Config vars
 ~~~~~~~~~~~
 
 :primary: Primary color
-:primary_opaque: Primary color with opaqueness. Example ``rgba(150, 26, 26, .5)``
+:primary-opaque: Primary color with opaqueness. Example ``rgba(150, 26, 26, .5)``
 :secondary: Secondary color
 :cover: Text color on the cover
 :white: A color representing white


### PR DESCRIPTION
The [docs](https://sphinx-simplepdf.readthedocs.io/en/latest/configuration.html#config-vars) use `primary_opaque`, but [_variables.scss](https://github.com/useblocks/sphinx-simplepdf/blob/1368138b3679c9bcceafd45057320e90fff50777/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_variables.scss#L7) uses `primary-opaque`. `primary-opaque` also matches the style of the other variables.

docs preview build: https://sphinx-simplepdf--126.org.readthedocs.build/en/126/configuration.html#config-vars