### PR TITLE
Docs: Update broken demo PDF link in css.rst

### DIFF
--- a/docs/css.rst
+++ b/docs/css.rst
@@ -85,7 +85,7 @@ rows and columns. Together with  :ref:`css_orientation` huge tables can be prese
           :file: /_static/example.csv
           :class: ssp-tiny
 
-Take a look into our `Demo PDF </_static/Sphinx-SimplePDF-DEMO.pdf>`_ for some examples of how tables could look like.
+Take a look into our `Demo PDF </en/latest/_static/Sphinx-SimplePDF-DEMO.pdf>`_ for some examples of how tables could look like.
 
 
 Sphinx-Needs elements


### PR DESCRIPTION
Note that this hard codes `en/latest/` in the URL and won't work for `en/stable/`, PR preview builds, etc.

(You can close if this is too hacky)

Fixes https://github.com/useblocks/sphinx-simplepdf/issues/106