### PR TITLE
Translate German comments in test files to English

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,16 +93,16 @@ class SphinxBuild:
 
             debug_buffer = io.StringIO() if debug else None
 
-            # Eigenen Handler OHNE Sphinx-Filter für Debug
+            # Custom handler without Sphinx filter for debug output
             debug_handler = logging.StreamHandler(debug_buffer)
             debug_handler.setLevel(logging.DEBUG)
             debug_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 
-            # An Extension-Logger hängen (umgeht Sphinx-Filter!)
+            # Attach to extension logger (bypasses Sphinx filter)
             ext_logger = sphinx_logging.getLogger("sphinx_simplepdf")
             ext_logger.logger.addHandler(debug_handler)
             ext_logger.logger.setLevel(logging.DEBUG)
-            ext_logger.logger.propagate = False  # Verhindere Doppel-Logging
+            ext_logger.logger.propagate = False  # Prevent duplicate logging
 
         self.app.build(force_all=force_all)
         self.outdir = Path(self.app.builder.outdir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from pdfminer.high_level import extract_pages, extract_text
 
 
 def extract_pdf_text(pdf_path):
-    """Extrahiere gesamten Text aus PDF."""
+    """Extract all text from a PDF."""
     return extract_text(str(pdf_path))
 
 
@@ -21,7 +21,7 @@ def prettify_html(html):
 
 
 def build_and_capture_stdout(sphinx_build, capsys, srcdir, build_kwargs=None, **sphinx_kwargs):
-    """Baue das PDF und liefere das captured stdout zurück."""
+    """Build the PDF and return the result with captured stdout."""
     build_kwargs = build_kwargs or {}
     result = sphinx_build(srcdir=srcdir, **sphinx_kwargs).build(**build_kwargs)
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

- Translated German comments and docstrings in `tests/conftest.py` and `tests/utils.py` to English for consistency with the rest of the codebase.

Fixes #140

## Changes

- `tests/conftest.py`: 3 inline comments translated
- `tests/utils.py`: 2 docstrings translated

## Test plan

- [x] Pre-commit hooks pass
- No functional changes — comments/docstrings only