### PR TITLE
Fix commented-out assertion and replace skipped test with real fixture

### DIFF
--- a/tests/doc_test/with_missing_image/conf.py
+++ b/tests/doc_test/with_missing_image/conf.py
@@ -1,0 +1,8 @@
+"""Configuration for testing missing image warnings."""
+
+project = "MissingImageTest"
+extensions = ["sphinx_simplepdf"]
+master_doc = "index"
+exclude_patterns = ["_build"]
+
+simplepdf_theme = "simplepdf_theme"

--- a/tests/doc_test/with_missing_image/index.rst
+++ b/tests/doc_test/with_missing_image/index.rst
@@ -1,0 +1,9 @@
+Document with Missing Image
+===========================
+
+This document references an image that does not exist.
+
+.. image:: _static/nonexistent_image.png
+   :alt: This image does not exist
+
+Content after the missing image.

--- a/tests/test_basic_build.py
+++ b/tests/test_basic_build.py
@@ -10,7 +10,6 @@ def test_basic_build_succeeds(sphinx_build, capsys):
     result = build_and_capture_stdout(sphinx_build, capsys, srcdir="basic_doc")
 
     assert result.pdf_exists()
-    # assert not result.has_warnings()
     assert not result.has_warnings("ERROR:")
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -17,10 +17,13 @@ def test_broken_anchors_warning(sphinx_build, capsys):
     assert len(anchor_warnings) > 0
 
 
-def test_missing_image_warning(sphinx_build, tmp_path):
+def test_missing_image_warning(sphinx_build, capsys):
     """Test that missing images produce warnings."""
-    # This would require a test doc with broken image reference
-    pytest.skip("Requires test doc with broken image")
+    result = build_and_capture_stdout(sphinx_build, capsys, srcdir="with_missing_image")
+
+    assert result.has_warnings()
+    image_warnings = result.get_warnings_matching(r"(image|nonexistent|not found|not readable)")
+    assert len(image_warnings) > 0
 
 
 def test_build_warnings_are_captured(sphinx_build, capsys):


### PR DESCRIPTION
## Summary

- Removed commented-out `assert not result.has_warnings()` in `test_basic_build.py` — the existing `ERROR`-level check is the correct assertion since basic builds may produce non-error warnings (e.g. from WeasyPrint about CSS/fonts)
- Replaced the unconditionally skipped `test_missing_image_warning` with a real test that uses a new `with_missing_image` test fixture referencing a nonexistent image file

Fixes #141

## Changes

- `tests/test_basic_build.py`: removed commented-out assertion
- `tests/test_warnings.py`: replaced `pytest.skip()` with actual test logic
- `tests/doc_test/with_missing_image/`: new minimal test fixture with a broken image reference

## Test plan

- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)
- [ ] CI tests pass on Ubuntu and Windows (requires WeasyPrint system deps not available on macOS)