### PR TITLE
Fix typos in the docs, demo, and code comments

### DIFF
--- a/demo/lists_tables.rst
+++ b/demo/lists_tables.rst
@@ -381,7 +381,7 @@ Tables with non-breakable text
   :class: ssp-table-wrap
 
   * - True
-    - This text could be broken at all whitespaces occuring in the text
+    - This text could be broken at all whitespaces occurring in the text
   * - False
     - This is a code block line, normaly could also be broken at all whitespaces in text
   * - True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,7 @@ Release 1.5
 :released: 26.10.2022
 
 * **Enhancement**: ``nocover`` option for :ref:`theme_options`.
-* **Enhancement**: New config options to directly configue the weasyprint build.
+* **Enhancement**: New config options to directly configure the weasyprint build.
 * **Enhancement**: New config option :ref:`simplepdf_file_name` allows to specify the output file name.
 * **Enhancement**: Provides :ref:`pdf-include` directive to embed PDF files in HTML views.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,7 +25,7 @@ The key is used as identifier inside scss-files and the value must be a css/scss
        'bottom-center-content': '"Custom footer content"',
    }
 
-This values are used then inside the scss files, which define the PDF layout.
+These values are used then inside the scss files, which define the PDF layout.
 
 Config vars
 ~~~~~~~~~~~
@@ -37,7 +37,7 @@ Config vars
 :white: A color representing white
 :links: Color for links
 :cover-bg: Cover background image. Can be a single color or even an image path.
-:cover-overlay: RBG based color overlay for the cover-image. Example: ``rgba(250, 35, 35, 0.5)``
+:cover-overlay: RGB based color overlay for the cover-image. Example: ``rgba(250, 35, 35, 0.5)``
 :top-left-content: Text or css function to display on pdf output. Example: ``counter(page)``
 :top-center-content: Text or css function to display on pdf output.
 :top-right-content: Text or css function to display on pdf output.
@@ -106,7 +106,7 @@ Default: project name
 
 simplepdf_debug
 ----------------
-A boolean value. If set to ``True``, **Sphinx-SimplePDF** will add some debug information add the end of the PDF.
+A boolean value. If set to ``True``, **Sphinx-SimplePDF** will add some debug information at the end of the PDF.
 
 This contains data about the used Python Environment and the Sphinx project.
 It is mainly used if any problems occur and extra information is needed.
@@ -124,7 +124,7 @@ simplepdf_use_weasyprint_api
 ----------------------------
 .. versionadded:: 1.6
 
-This forces simplepdf to use the weasyprint `python API <https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#python-api>`_ instead of calling the binary via subproces.
+This forces simplepdf to use the weasyprint `python API <https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#python-api>`_ instead of calling the binary via subprocess.
 
 ``simplepdf_use_weasyprint_api = True``
 
@@ -136,7 +136,7 @@ simplepdf_weasyprint_flags
 --------------------------
 .. versionadded:: 1.5
 
-List of flags to pass to **weasyprint** subprocess. This may be helpfull in debugging the pdf creation
+List of flags to pass to **weasyprint** subprocess. This may be helpful in debugging the pdf creation
 
 ``simplepdf_weasyprint_flags = ['-v']``
 
@@ -158,7 +158,7 @@ simplepdf_weasyprint_retries
 .. versionadded:: 1.6
 
 In rare cases **weasyprint** seems to run into infinite loops during processing of the input file.
-In case a ``subprocess.TimeoutExpired`` exception occured and retries are configured **weasyprint** is started again.
+In case a ``subprocess.TimeoutExpired`` exception occurred and retries are configured **weasyprint** is started again.
 
 ``simplepdf_weasyprint_retries = 1``
 
@@ -190,4 +190,4 @@ To reduce output noise the output can be filtered by a list of regular expressio
 
 ``simplepdf_weasyprint_filter = ["WARNING: Ignored"]``
 
-To suppress all output, the quite flag `-q` should be used.
+To suppress all output, the quiet flag `-q` should be used.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,7 +46,7 @@ Config vars
 :bottom-right-content: Text or css function to display on pdf output.
 
 
-All variables are defined inside ``/themes/sphinx_simplepdf/sttuc/stles/sources/_variables.scss``.
+All variables are defined inside ``sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_variables.scss``.
 
 .. hint::
 
@@ -76,7 +76,7 @@ File references
    }
 
 The file path must be relative to the Sphinx _static folder.
-So in the above example the image is stored under ``/_static/cover-bg-jpg``.
+So in the above example the image is stored under ``/_static/cover-bg.jpg``.
 
 SimplePDF docs
 ++++++++++++++

--- a/docs/css.rst
+++ b/docs/css.rst
@@ -27,7 +27,7 @@ If this is set to ``break``, then a page break will be introduced in front of th
 Page Orientation
 ~~~~~~~~~~~~~~~~
 
-The default orientation is portrait. To change the page orientation for a side, you can add the css class
+The default orientation is portrait. To change the page orientation for a page, you can add the css class
 ``ssp-landscape`` to
 
 * directives supporting the option ``:class:``
@@ -57,7 +57,7 @@ Table content wrap
 ~~~~~~~~~~~~~~~~~~
 
 By default table content is wrapped at whitespaces. If you have table content that can not be wrapped due to
-side limitations, the table is drawn out of the margins. This behaviour can be changed by using the css class
+size limitations, the table is drawn out of the margins. This behaviour can be changed by using the css class
 ``ssp-table-wrap``. This allows the table to break the content anywhere.
 
 This requires a fixed table layout, so you have to set the ``widths`` options (or e.g. ``colwidths`` option
@@ -113,5 +113,5 @@ config() functions
 Inside ``scss`` files you can use ``config(name, default)`` to get access to the values from
 ``simplepdf_vars``.
 
-The **default** values is used, if the **name** can not be found inside ``simplepdf_vars``, which is the normal case, as
+The **default** value is used, if the **name** can not be found inside ``simplepdf_vars``, which is the normal case, as
 ``simplepdf_vars`` is an empty dictionary by default.

--- a/docs/css.rst
+++ b/docs/css.rst
@@ -41,7 +41,7 @@ The default orientation is portrait. To change the page orientation for a side, 
     .. csv-table:: CSV Table
        :file: example.csv
 
-    .. or as alternaitve
+    .. or as alternative
 
     .. container:: break_before ssp-landscape
 

--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -56,7 +56,7 @@ chosen builder name. The argument is case-insensitive.
 
 .. note:: Why not using the ``.. only::`` directive?
 
-   The ``only`` directive works differently and does not support for instance ``toctree`` and other mechanism for
+   The ``only`` directive works differently and does not support for instance ``toctree`` and other mechanisms for
    controlling the documentation structure.
 
 .. _if-include:
@@ -102,7 +102,7 @@ The following chapter should only be visible in the PDF version of this document
 
 pdf-include
 -----------
-Includes a PDF file inside the the HTML code.
+Includes a PDF file inside the HTML code.
 The browser decides mostly, what kind of PDF-viewer.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-From PyPi
+From PyPI
 ---------
 
 .. code-block:: bash
@@ -30,7 +30,7 @@ In this case please run also ``brew install pango``.
 
 Windows installation
 ~~~~~~~~~~~~~~~~~~~~
-**Sphinx-SimplePDF** is based on WeasypPrint, which is not so easy to get installed on Windows.
+**Sphinx-SimplePDF** is based on WeasyPrint, which is not so easy to get installed on Windows.
 
 Please follow their instructions about
 `how to install WeasyPrint on Windows <https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#windows>`_.
@@ -55,7 +55,7 @@ ReadTheDocs configuration
 -------------------------
 **Sphinx-SimplePDF** can be also used on `Read The Docs (RTD) <https://readthedocs.io>`_ to generate your PDF.
 As it is not supported by RTD by default, you need to create a ``.readthedocs.yaml`` configuration file on the root level
-of our project.
+of your project.
 
 You can take the one from **Sphinx-SimplePDF** as a good example:
 

--- a/docs/tech_details.rst
+++ b/docs/tech_details.rst
@@ -6,7 +6,7 @@ A sphinx builder, called ``simplepdf``. Code inside ``/builders/simplepdf.py``.
 
 A sphinx theme, called ``sphinx-simplepdf``. Files under ``/themes/sphinx_simplepdf``.
 
-During package installation, builder and theme get registered for Sphinx. This is done via the ``enytry__points``
+During package installation, builder and theme get registered for Sphinx. This is done via the ``entry_points``
 mechanism.
 
 .. literalinclude:: ../pyproject.toml
@@ -33,7 +33,7 @@ DEMO project
 The DEMO project is stored under `/demo/` and provides a common way for all
 developers and users to test everything on a common base.
 
-It can be build by the following steps:
+It can be built by the following steps:
 
 - ``git clone git@github.com:useblocks/sphinx-simplepdf.git``
 - ``cd sphinx-simplepdf``

--- a/docs/tech_details.rst
+++ b/docs/tech_details.rst
@@ -25,7 +25,7 @@ Workflow
 
    * Fixes toc-tree links
 
-7. Builders starts **weasyprint** with ``index.html`` as input
+7. Builder starts **weasyprint** with ``index.html`` as input
 8. Done, PDF file exists under ``_build/simplepdf``.
 
 DEMO project

--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -235,8 +235,8 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
 
                 occurences = soup.find_all("section", attrs={"id": cleaned_ref_target})
 
-                # name occurences section-id which is the target for internal refs with increasing id
-                # occurence-0, occurence-1, occurence-2 ...
+                # name occurrences section-id which is the target for internal refs with increasing id
+                # occurrence-0, occurrence-1, occurrence-2 ...
                 if len(occurences) > 1:
                     occ_counter = 0
                     for occ_counter, occ in enumerate(occurences):
@@ -248,9 +248,9 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                 # index of toctree entry
                 replace_counter = 0
 
-                # scan all occurences, if occurenca has too high of a HTML headline level compared to the max_toctree_level (depth)
-                # the occurence is a "deeper" level which does not correspond to the toctree refernce. This is only needed when there
-                # are chaptters with the same name AND one of them is at a level which should not be referenced in the toc but becomes an
+                # scan all occurrences, if occurrence has too high of a HTML headline level compared to the max_toctree_level (depth)
+                # the occurrence is a "deeper" level which does not correspond to the toctree reference. This is only needed when there
+                # are chapters with the same name AND one of them is at a level which should not be referenced in the toc but becomes an
 
                 for toc_link in toc_links:
                     if toc_link["href"] == cleaned_ref_toc:
@@ -282,7 +282,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                                             target_lvl = int(name[-1])
 
                                             # if headlinelevel either is max_toctree lvl or + 1 the chapter should be included in the toc
-                                            # break both loops and edit occurrence via repalce_counter
+                                            # break both loops and edit occurrence via replace_counter
                                             if target_lvl == max_toctree_lvl + 1 or target_lvl == max_toctree_lvl:
                                                 match_found = True
                                                 break  # headline match found
@@ -292,7 +292,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                                                 replace_counter += 1
                                                 continue
 
-                            # edit target of toc reference with correct occurence
+                            # edit target of toc reference with correct occurrence
                             toc_link["href"] = toc_link["href"] + "-" + str(replace_counter)
                             replace_counter += 1
 


### PR DESCRIPTION
## Summary

- Fix typos and paths in the docs
- Fix typos in demo
- Fix typos in code comments

docs preview: https://sphinx-simplepdf--145.org.readthedocs.build/en/145/