### PR TITLE
Add warning log when all weasyprint retries are exhausted

### DIFF
--- a/sphinx_simplepdf/builders/simplepdf.py
+++ b/sphinx_simplepdf/builders/simplepdf.py
@@ -215,6 +215,7 @@ class SimplePdfBuilder(SingleFileHTMLBuilder):
                     logger.info(f"CalledProcessError in weasyprint, retrying\n{e!s}")
                 finally:
                     if (n == retries - 1) and not success:
+                        logger.warning(f"weasyprint failed after {retries} retries")
                         raise RuntimeError(f"maximum number of retries {retries} failed in weasyprint")
 
     """


### PR DESCRIPTION
## Summary

- Adds `logger.warning()` when all WeasyPrint retries are exhausted, right before the `RuntimeError` is raised
- Intermediate retry messages remain at `logger.info()` to avoid breaking `-W` (warnings as errors) builds on transient failures

Closes #142

## Test plan

- [ ] Verify intermediate retries still log at `info` level
- [ ] Verify final failure emits a `warning` before raising `RuntimeError`
- [ ] Confirm `-W` builds are not broken by a retry that eventually succeeds