### PR TITLE
Move dev tools out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,10 @@ classifiers = [
   "Topic :: Software Development :: Documentation",
 ]
 dependencies = [
-  "pre-commit>=3.5",
   "sphinx>=7.0",
   "weasyprint==67.0",
   "libsass",
   "beautifulsoup4",
-  "packaging>=20.0",  # Modern replacement for pkg_resources.parse_version
-  "pytest>=7.0",
 ]
 
 [project.urls]
@@ -48,6 +45,7 @@ simplepdf = "sphinx_simplepdf.builders.simplepdf"
 # [project.optional-dependencies]
 [dependency-groups]
 dev = [
+  "pre-commit>=3.5",
   "pytest>=7.0",
   "pytest-xdist>=3.0",
   "pytest-cov",

--- a/uv.lock
+++ b/uv.lock
@@ -1958,9 +1958,6 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "libsass" },
-    { name = "packaging" },
-    { name = "pre-commit" },
-    { name = "pytest" },
     { name = "sphinx" },
     { name = "weasyprint" },
 ]
@@ -1975,6 +1972,7 @@ demo = [
 dev = [
     { name = "opencv-python" },
     { name = "pdfminer-six" },
+    { name = "pre-commit" },
     { name = "pymupdf" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1999,9 +1997,6 @@ docs = [
 requires-dist = [
     { name = "beautifulsoup4" },
     { name = "libsass" },
-    { name = "packaging", specifier = ">=20.0" },
-    { name = "pre-commit", specifier = ">=3.5" },
-    { name = "pytest", specifier = ">=7.0" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "weasyprint", specifier = "==67.0" },
 ]
@@ -2016,6 +2011,7 @@ demo = [
 dev = [
     { name = "opencv-python", specifier = ">=4.8.0" },
     { name = "pdfminer-six", specifier = ">=20220319" },
+    { name = "pre-commit", specifier = ">=3.5" },
     { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-cov" },


### PR DESCRIPTION
## Summary
- Remove `pre-commit`, `pytest`, and the unused `packaging` dependency from runtime dependencies.
- Keep `pre-commit` in the `dev` dependency group, where `pytest` already lives.
- Update the editable package metadata in `uv.lock` to match `pyproject.toml`.

## Validation
- `git diff --check`
- `git diff --cached --check`
- Reviewed `rg --line-number packaging|pre-commit|pytest|pkg_resources|parse_version pyproject.toml sphinx_simplepdf tests docs .github uv.lock`
- Not run locally

Closes #138