### PR TITLE
Fix Fira Mono font-face declarations

### DIFF
--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_fonts.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_fonts.scss
@@ -57,19 +57,19 @@
  }
 
 @font-face {
-    font-family: FiraMono, monospace;
+    font-family: "Fira Mono";
     src: url(fonts/FiraMono-Regular.ttf);
 }
 
 
 @font-face {
-    font-family: Fira Mono, monospace;
-    font-weight: 400;
+    font-family: "Fira Mono";
+    font-weight: 500;
     src: url(fonts/FiraMono-Medium.ttf);
 }
 
 @font-face {
-    font-family: Fira Mono, monospace;
+    font-family: "Fira Mono";
     font-weight: bold;
     src: url(fonts/FiraMono-Bold.ttf);
 }

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/main.scss
@@ -60,6 +60,7 @@ body {
 
 .highlight {
   pre {
+    font-family: "Fira Mono", monospace;
     padding: 1em;
     //white-space: -moz-pre-wrap;
     white-space: -o-pre-wrap;
@@ -171,6 +172,7 @@ img {
     hyphens: none;
     color: #552977;
     background-color: #f1f1f1;
+    font-family: "Fira Mono", monospace;
     font-size: 9pt;
     padding: 1pt 3pt;
 }


### PR DESCRIPTION
## Summary
- use a single quoted `Fira Mono` family name across the Fira Mono `@font-face` declarations
- set the medium face to weight `500` so it matches the bundled medium font
- reference `Fira Mono` with a `monospace` fallback for code blocks and inline literals

Closes #136

## Validation
- `git diff --check HEAD~1..HEAD`
- reviewed the Fira Mono font-family declarations and code font usages
- Tests not run locally.