### PR TITLE
Improve page break support for tables

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* **Bugfix**: [#155] Prevent table rows from splitting across pages.
 * **Bugfix** [#134] Improve support for external theme packages by using a ``get_scss_sources_path()`` convention.
 
   - If needed, theme warnings can be suppressed via ``suppress_warnings = ["simplepdf.theme"]``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-* **Bugfix**: [#155] Prevent table rows from splitting across pages.
+* **Bugfix**: [#155] Prevent table rows from splitting across pages and table captions from separating from their tables.
 * **Bugfix** [#134] Improve support for external theme packages by using a ``get_scss_sources_path()`` convention.
 
   - If needed, theme warnings can be suppressed via ``suppress_warnings = ["simplepdf.theme"]``.

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
@@ -16,6 +16,11 @@ table.docutils {
     background-color: transparent;
     border-spacing: 0;
 
+    caption {
+        page-break-after: avoid;
+        break-after: avoid-page;
+    }
+
     td, th {
         padding: .75rem;
         vertical-align: top;

--- a/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
+++ b/sphinx_simplepdf/themes/simplepdf_theme/static/styles/sources/_tables.scss
@@ -32,6 +32,9 @@ table.docutils {
 
     tbody {
         tr {
+            page-break-inside: avoid;
+            break-inside: avoid-page;
+
             &.row-odd {
                 background: #f6f6f6;
             }


### PR DESCRIPTION
## Summary of changes

- Prevent splitting table rows across pages
- Prevent page breaks after table captions

Each uses both the old and new CSS rules. Note that WeasyPrint can still break the table row if it is longer than a page.